### PR TITLE
Addresses dependency build failures and rebases against Stackage master

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -4137,6 +4137,7 @@ skipped-benchmarks:
     - pipes # optparse-applicative 0.13
     - splitmix # criterion 1.3
     - superbuffer # criterion 1.3
+    - text-builder # criterion 1.1 https://github.com/commercialhaskell/stackage/issues/3668
     - ttrie # criterion-plus and th-pprint
     - tz # criterion 1.3
     - unicode-transforms # criterion 1.3

--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -1991,7 +1991,7 @@ packages:
     "Timo von Holtz <tvh@tvholtz.de> @tvh":
         - ekg-wai
         # - haxl-amazonka # http-conduit 2.3 via amazonka
-        - hasql-migration
+        - hasql-migration < 0 # https://github.com/tvh/hasql-migration/issues/4
         - servant-JuicyPixels < 0 # GHC 8.4 via base-4.11.0.0
 
     "Artyom <yom@artyom.me> @neongreen":
@@ -2317,7 +2317,7 @@ packages:
     "Yorick Laupa yo.eight@gmail.com @YoEight":
         - eventstore < 0 # GHC 8.4 via text-format
         - dotnet-timespan
-        - eventsource-api
+        - eventsource-api < 0 # GHC 8.4 build failure
         - eventsource-geteventstore-store < 0 # GHC 8.4 via protolude
         - eventsource-store-specs < 0 # tasty-hspec
         - eventsource-stub-store < 0 # GHC 8.4 via protolude

--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2317,7 +2317,7 @@ packages:
     "Yorick Laupa yo.eight@gmail.com @YoEight":
         - eventstore < 0 # GHC 8.4 via text-format
         - dotnet-timespan
-        - eventsource-api < 0 # https://github.com/YoEight/eventsource-api/issues/4
+        - eventsource-api
         - eventsource-geteventstore-store < 0 # GHC 8.4 via protolude
         - eventsource-store-specs < 0 # tasty-hspec
         - eventsource-stub-store < 0 # GHC 8.4 via protolude

--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -1213,10 +1213,26 @@ packages:
         - cryptohash-sha1
 
     "Renzo Carbonara <renzocarbonara@gmail.com> @k0001":
+        - df1
+        - di
+        - di-core
+        - di-df1
+        - di-handle
+        - di-monad
+        - exinst
+        - flay
         - network-simple
+        - network-simple-tls
         - pipes-aeson
         - pipes-attoparsec
+        - pipes-binary
         - pipes-network
+        - pipes-network-tls
+        - safe-money
+        - vector-bytes-instances
+        - xmlbf-xeno
+        - xmlbf-xmlhtml
+        - xmlbf
 
     "Tomas Carnecky @wereHamster":
         # - avers # cryptonite 0.25

--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -1219,7 +1219,7 @@ packages:
         - di-df1
         - di-handle
         - di-monad
-        - exinst
+        - exinst < 0 # via serialize and cborg https://github.com/commercialhaskell/stackage/issues/3666 and 3667
         - flay
         - network-simple
         - network-simple-tls
@@ -1228,10 +1228,10 @@ packages:
         - pipes-binary
         - pipes-network
         - pipes-network-tls
-        - safe-money
+        - safe-money < 0 # via serialise https://github.com/commercialhaskell/stackage/issues/3666
         - vector-bytes-instances
         - xmlbf-xeno
-        - xmlbf-xmlhtml
+        - xmlbf-xmlhtml < 0 # GHC 8.4 via xmlhtml via hspec-2.5.0
         - xmlbf
 
     "Tomas Carnecky @wereHamster":

--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -3709,7 +3709,6 @@ skipped-tests:
     # Compilation failures
     - proto-lens-combinators # https://github.com/google/proto-lens/issues/119
     - pell # https://github.com/brunjlar/pell/issues/1
-    - protobuf # https://github.com/alphaHeavy/protobuf/issues/34
     - store # https://github.com/fpco/store/issues/125
 
     # Runtime issues


### PR DESCRIPTION
I've attempted to address the build failures in commercialhaskell/stackage#3658 as follows

- drop `exinst` with a comment that it's blocked by `serialise` and `cborg`
- drop `safe-money` with a comment that it's blocked by `serialise`
- drop `xmlbf-xmlhtml` with a comment that it's blocked by `xmlhtml` (which is blocked by a dependency on `hspec-2.5.0`)

I've also rebased this against `master` so it should pass CI, but I'm not terribly sure how good GitHub's web UI is about these sorts of merges.